### PR TITLE
remove support for Firefox 52-61

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,8 @@ module.exports = {
         "es6": true,
     },
     "parserOptions": {
-        "ecmaVersion": 2017,
+        "ecmaVersion": 2018,
+        "sourceType": "module",
     },
     "extends": "eslint:recommended",
     "rules": {

--- a/background.js
+++ b/background.js
@@ -1,5 +1,7 @@
-/* globals getOptions, onError, IconDrawer, migrate */
-"use strict";
+import { getOptions, onError } from "./shared.js";
+import { migrate } from "./migrate.js";
+import { IconDrawer } from "./icondrawer.js";
+
 async function main() {
     /* eslint no-restricted-properties: ["error", {
         "property": "addListener",

--- a/background.js
+++ b/background.js
@@ -1,4 +1,4 @@
-/* globals getOptions, onError, supportsWindowId, supportsTabReset, IconDrawer, migrate */
+/* globals getOptions, onError, IconDrawer, migrate */
 "use strict";
 async function main() {
     /* eslint no-restricted-properties: ["error", {
@@ -6,8 +6,6 @@ async function main() {
     }] */
     await migrate();
     const options = await getOptions();
-    const useWindowId = await supportsWindowId();
-    const doTabReset = await supportsTabReset();
 
     let setText;
     let drawer;
@@ -76,9 +74,7 @@ async function main() {
             }
             return;
         }
-        if (doTabReset) {
-            await resetBadgeIconAll();
-        }
+        await resetBadgeIconAll();
         removeListeners();
         main();
     });
@@ -86,23 +82,18 @@ async function main() {
     async function resetBadgeIconAll() {
         resetBadgeIcon(null);
         if (options.scope === "global") return;
-        if (useWindowId) {
-            const tabs = await browser.tabs.query({active: true});
-            await Promise.all(tabs.map(i => resetBadgeIcon({windowId: i.windowId})));
-        } else {
-            const tabs = await browser.tabs.query({});
-            await Promise.all(tabs.map(i => resetBadgeIcon({tabId: i.id})));
-        }
+        const tabs = await browser.tabs.query({active: true});
+        await Promise.all(tabs.map(i => resetBadgeIcon({windowId: i.windowId})));
     }
 
     async function resetBadgeIcon(spec) {
         if (options.displayMode === "badge") {
             await browser.browserAction.setBadgeText(
-                Object.assign({text: null}, spec),
+                {text: null, ...spec},
             );
         } else if (options.displayMode === "icon") {
             await browser.browserAction.setIcon(
-                Object.assign({imageData: null}, spec),
+                {imageData: null, ...spec},
             );
         } else {
             onError("invalid displayMode");
@@ -125,22 +116,6 @@ async function main() {
         await setText({windowId: windowId}, [tabs.length.toString()]);
     }
 
-    async function updateActive(windowId) {
-        const tabs = await tabsQueryFilter({windowId: windowId});
-        const active = tabs.filter(i => i.active)[0];
-        await setText({tabId: active.id}, [tabs.length.toString()]);
-    }
-
-    async function updateActives() {
-        const tabs = await tabsQueryFilter({active: true});
-        await Promise.all(tabs.map(i => updateTab(i.id, i.windowId)));
-    }
-
-    async function updateTab(tabId, windowId) {
-        const tabs = await tabsQueryFilter({windowId: windowId});
-        await setText({tabId: tabId}, [tabs.length.toString()]);
-    }
-
     async function updateBoth() {
         const tabs = await tabsQueryFilter({});
         const total = tabs.length;
@@ -161,45 +136,11 @@ async function main() {
         }
     }
 
-    async function updateBothTab() {
-        const tabs = await tabsQueryFilter({});
-        const total = tabs.length;
-        let counts = new Map();
-        let actives = new Map();
-        for (let i of tabs) {
-            if (counts.has(i.windowId)) {
-                counts.set(i.windowId, counts.get(i.windowId) + 1);
-            } else {
-                counts.set(i.windowId, 1);
-            }
-            if (i.active) {
-                actives.set(i.windowId, i.id);
-            }
-        }
-        if (counts.size === 1) {
-            const active = actives.values().next().value;
-            await setText({tabId: active}, [total.toString()]);
-            return;
-        }
-        for (let [i, active] of actives) {
-            const n = counts.get(i);
-            await setText({tabId: active}, [n.toString(), total.toString()]);
-        }
-    }
-
     async function initializeCounters() {
         if (options.scope === "window") {
-            if (useWindowId) {
-                updateWindows();
-            } else {
-                updateActives();
-            }
+            updateWindows();
         } else if (options.scope === "both") {
-            if (useWindowId) {
-                updateBoth();
-            } else {
-                updateBothTab();
-            }
+            updateBoth();
         } else if (options.scope === "global") {
             updateGlobal();
         } else {
@@ -208,13 +149,12 @@ async function main() {
     }
 
     async function setTextBadge(spec, text) {
-        await browser.browserAction.setBadgeText(Object.assign({text: text[0]}, spec));
+        await browser.browserAction.setBadgeText({text: text[0], ...spec});
     }
-
 
     async function setTextIcon(spec, text) {
         const data = drawer.draw(text, options.iconMargin / 100, options.iconColor);
-        await browser.browserAction.setIcon(Object.assign({imageData: data}, spec));
+        await browser.browserAction.setIcon({imageData: data, ...spec});
     }
 
     if (options.displayMode === "badge") {
@@ -241,83 +181,35 @@ async function main() {
     }
 
     if (options.scope === "window") {
-        if (useWindowId) {
-            addListener(browser.tabs.onRemoved, (tabId, removeInfo) => {
-                filterTabs.push(tabId);
-                updateWindow(removeInfo.windowId);
-            });
-            addListener(browser.tabs.onDetached, (_, detachInfo) => {
-                updateWindow(detachInfo.oldWindowId);
-            });
-            addListener(browser.tabs.onCreated, tab => {
-                filterTabs = [];
-                updateWindow(tab.windowId);
-            });
-            addListener(browser.tabs.onAttached, (_, attachInfo) => {
-                updateWindow(attachInfo.newWindowId);
-            });
+        addListener(browser.tabs.onRemoved, (tabId, removeInfo) => {
+            filterTabs.push(tabId);
+            updateWindow(removeInfo.windowId);
+        });
+        addListener(browser.tabs.onDetached, (_, detachInfo) => {
+            updateWindow(detachInfo.oldWindowId);
+        });
+        addListener(browser.tabs.onCreated, tab => {
+            filterTabs = [];
+            updateWindow(tab.windowId);
+        });
+        addListener(browser.tabs.onAttached, (_, attachInfo) => {
+            updateWindow(attachInfo.newWindowId);
+        });
 
-            updateWindows();
-        } else {
-            addListener(browser.tabs.onActivated, activeInfo => {
-                updateTab(activeInfo.tabId, activeInfo.windowId);
-            });
-            addListener(browser.tabs.onDetached, (_, detachInfo) =>{
-                updateActive(detachInfo.oldWindowId);
-            });
-            addListener(browser.tabs.onAttached, (_, attachInfo) =>{
-                updateActive(attachInfo.newWindowId);
-            });
-            addListener(browser.tabs.onCreated, tab => {
-                filterTabs = [];
-                updateTab(tab.id, tab.windowId);
-            });
-            addListener(browser.tabs.onRemoved, (tabId, removeInfo) => {
-                filterTabs.push(tabId);
-                updateActive(removeInfo.windowId);
-            });
-            addListener(browser.tabs.onUpdated, (tabId, changeInfo, tab) => {
-                if ("url" in changeInfo && tab.active) {
-                    updateTab(tabId, tab.windowId);
-                }
-            });
-
-            updateActives();
-        }
+        updateWindows();
     } else if (options.scope === "both") {
-        if (useWindowId) {
-            addListener(browser.tabs.onDetached, updateBoth);
-            addListener(browser.tabs.onAttached, updateBoth);
-            addListener(browser.tabs.onCreated, () => {
-                filterTabs = [];
-                updateBoth();
-            });
-            addListener(browser.tabs.onRemoved, tabId => {
-                filterTabs.push(tabId);
-                updateBoth();
-            });
-
+        addListener(browser.tabs.onDetached, updateBoth);
+        addListener(browser.tabs.onAttached, updateBoth);
+        addListener(browser.tabs.onCreated, () => {
+            filterTabs = [];
             updateBoth();
-        } else {
-            addListener(browser.tabs.onActivated, updateBothTab);
-            addListener(browser.tabs.onDetached, updateBothTab);
-            addListener(browser.tabs.onAttached, updateBothTab);
-            addListener(browser.tabs.onCreated, () => {
-                filterTabs = [];
-                updateBothTab();
-            });
-            addListener(browser.tabs.onRemoved, tabId => {
-                filterTabs.push(tabId);
-                updateBothTab();
-            });
-            addListener(browser.tabs.onUpdated, (tabId, changeInfo, tab) => {
-                if ("url" in changeInfo && tab.active) {
-                    updateBothTab();
-                }
-            });
+        });
+        addListener(browser.tabs.onRemoved, tabId => {
+            filterTabs.push(tabId);
+            updateBoth();
+        });
 
-            updateBothTab();
-        }
+        updateBoth();
     } else if (options.scope === "global") {
         addListener(browser.tabs.onRemoved, tabId => {
             filterTabs.push(tabId);

--- a/icondrawer.js
+++ b/icondrawer.js
@@ -1,5 +1,4 @@
-/* exported IconDrawer, supportsActualBoundingBoxes */
-"use strict";
+export { IconDrawer, supportsActualBoundingBoxes };
 
 /*
  * Tests whether the TextMetrics.actualBoundingBoxAscent and

--- a/manifest.json
+++ b/manifest.json
@@ -5,11 +5,10 @@
     "description": "Shows number of open tabs. DEV",
     "browser_specific_settings": {
         "gecko": {
-            "strict_min_version": "52.0"
+            "strict_min_version": "62.0"
         }
     },
     "permissions": [
-        "tabs",
         "storage"
     ],
     "browser_action": {

--- a/manifest.json
+++ b/manifest.json
@@ -15,7 +15,7 @@
         "default_icon": "icons/ic_tab_black_24px.svg"
     },
     "background": {
-        "scripts": ["shared.js", "icondrawer.js", "migrate.js", "background.js"]
+        "page": "background.html"
     },
     "options_ui": {
         "page": "options.html",

--- a/migrate.js
+++ b/migrate.js
@@ -1,5 +1,5 @@
-/* exported migrate */
-"use strict";
+export { migrate };
+
 async function migrateMargin() {
     const cfg = await browser.storage.local.get("iconFontMultiplier");
     if ("iconFontMultiplier" in cfg) {

--- a/options.html
+++ b/options.html
@@ -122,8 +122,7 @@
         </form>
     </div>
 
-    <script defer src="shared.js"></script>
-    <script defer src="options.js"></script>
+    <script type="module" defer src="options.js"></script>
 </body>
 
 </html>

--- a/options.js
+++ b/options.js
@@ -1,4 +1,4 @@
-/* globals getOptions, onError, supportsTabReset */
+/* globals getOptions, onError */
 "use strict";
 
 function restoreOptions(opt) {
@@ -97,46 +97,16 @@ function fontDialogApply() {
 }
 
 async function initSaveEvents() {
-    const noReload = await supportsTabReset();
-    const reloadMsg =
-        "Extension reload necessary due to browser version.\n" +
-        "Reload Page (F5) if formatting is messed up";
     document.querySelectorAll("input[name='scope']").forEach(element => {
         element.addEventListener("input", e => {
             if (!e.target.checked) return;
-            let reload = false;
-            if ((!noReload) && e.target.value === "global") {
-                const ok = window.confirm(reloadMsg);
-                if (!ok) {
-                    restoreSavedOptions();
-                    return;
-                }
-                reload = true;
-            }
-            let p = browser.storage.local.set({"scope": e.target.value});
-            if (reload) {
-                p.then(() => browser.runtime.reload());
-            }
+            browser.storage.local.set({"scope": e.target.value});
         });
     });
     document.querySelectorAll("input[name='displayMode']").forEach(element => {
         element.addEventListener("input", e => {
             if (!e.target.checked) return;
-            let reload = false;
-            if (!noReload) {
-                const ok = window.confirm(
-                    reloadMsg,
-                );
-                if (!ok) {
-                    restoreSavedOptions();
-                    return;
-                }
-                reload = true;
-            }
-            let p = browser.storage.local.set({"displayMode": e.target.value});
-            if (reload) {
-                p.then(() => browser.runtime.reload());
-            }
+            browser.storage.local.set({"displayMode": e.target.value});
         });
     });
     document.getElementById("badgeBg").addEventListener("input", e => {

--- a/options.js
+++ b/options.js
@@ -1,5 +1,4 @@
-/* globals getOptions, onError */
-"use strict";
+import { getOptions, onError } from "./shared.js";
 
 function restoreOptions(opt) {
     switch (opt.scope) {

--- a/shared.js
+++ b/shared.js
@@ -1,4 +1,4 @@
-/* exported defaultOptions, getOptions, onError, supportsWindowId, supportsTabReset */
+/* exported defaultOptions, getOptions, onError */
 "use strict";
 
 var defaultOptions = {
@@ -28,32 +28,5 @@ function onError(error) {
     if (debugging) {
         // eslint-disable-next-line no-console
         console.log(`Error: ${error}`);
-    }
-}
-
-/* Whether `windowId` is supported as an parameter to browserAction.setIcon and
- * browserAction.setBadgeText
- * Firefox version >= 62
- */
-async function supportsWindowId() {
-    if (!browser.runtime.getBrowserInfo) return false;
-    try {
-        const info = await browser.runtime.getBrowserInfo();
-        return info.name === "Firefox" && parseInt(info.version, 10) >= 62;
-    } catch (e) {
-        return false;
-    }
-}
-
-/* Whether browserAction.setIcon and browserAction.setBadgeText support
- * resetting individual tabs icons/badges by passing `null`
- */
-async function supportsTabReset() {
-    if (!browser.runtime.getBrowserInfo) return false;
-    try {
-        const info = await browser.runtime.getBrowserInfo();
-        return info.name === "Firefox" && parseInt(info.version, 10) >= 59;
-    } catch (e) {
-        return false;
     }
 }

--- a/shared.js
+++ b/shared.js
@@ -1,5 +1,4 @@
-/* exported defaultOptions, getOptions, onError */
-"use strict";
+export { defaultOptions, getOptions, onError };
 
 var defaultOptions = {
     "scope": "window", // "global" | "window" | "both"


### PR DESCRIPTION
this guarantees that two api changes are available:
* the `windowId` parameter
* the ability to reset bages/icons (e.g. if you've set a tab-specific icon/badge but want it to display the global one)
* Edit: hidden tabs and related apis (`tabs.onUpdated.addListener` extra parameters)

the tabs permission was only needed to check if the url had changed on a
`tabs.onUpdated` event. This was required from Firefox 59 onwards because
the tab-specific (not window-specific, though) icon/badge would be cleared
when a new page was loaded.

---

~~I don't think I'm going to merge this anytime soon~~ but if I were to implement some new (bigger) changes this would probably be a necessity for me as it is now.

Feel free to comment if you care about support for systems where those newer APIs aren't available (for Firefox specifically versions 52-61 have been **unsupported** for some time now).